### PR TITLE
I don't use Abolish abbreviations anymore

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -235,6 +235,7 @@ vim.g.python3_host_prog = '~/py-envs/utils/bin/python'
 vim.g.is_posix = 1 -- ft=sh: correctly highlight $() ...
 
 require('noplugins')
+require('abbreviations')
 require('autocmds')
 require('readline')
 require('statusline')

--- a/lua/abbreviations.lua
+++ b/lua/abbreviations.lua
@@ -1,3 +1,4 @@
+vim.cmd([[
 iabbrev _dd Dimitar Dimitrov<c-r>=abbreviations#eat_char('\s')<cr>
 iabbrev _date <c-r>=strftime('%a, %d %b %Y')<cr><c-r>=abbreviations#eat_char('\s')<cr>
 
@@ -42,3 +43,4 @@ iabbrev convinience convenience
 iabbrev profesional professional
 " 12 words
 iabbrev colaboration collaboration
+]])


### PR DESCRIPTION
Thus, normal abbreviations don't don't need to be loaded 'after plugin'.
note: I don't use them as not really useful for that purpose + reduces considerably startup time